### PR TITLE
Replaced HasTeam

### DIFF
--- a/lua/terrortown/gamemode/shared/hud_elements/tttroundinfo/acrylic_roundinfo.lua
+++ b/lua/terrortown/gamemode/shared/hud_elements/tttroundinfo/acrylic_roundinfo.lua
@@ -62,7 +62,7 @@ if CLIENT then
 		-- Draw round time
 
 		local is_haste = HasteMode() and round_state == ROUND_ACTIVE
-		local is_traitor = not client:IsActive() or client:HasTeam(TEAM_TRAITOR)
+		local is_traitor = not client:IsActive() or client:GetTeam() == TEAM_TRAITOR
 		local endtime = GetGlobalFloat("ttt_round_end", 0) - CurTime()
 		local font = "AcrylicBar"
 		local color = COLOR_WHITE


### PR DESCRIPTION
This PR replaced `HasTeam` because it doesn't support parameter anymore since TTT2 v0.9.0b and GetTeam should be used instead.